### PR TITLE
Added testing keyword to promote adding as require-dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,7 @@
 {
   "name": "fig/log-test",
   "description": "Test utilities for the psr/log package that backs the PSR-3 specification.",
+  "keywords": ["testing"],
   "license": "MIT",
   "authors": [
     {


### PR DESCRIPTION
see https://getcomposer.org/doc/04-schema.md#keywords

> Note: Some special keywords trigger composer require without the --dev option to prompt users if they would like to add these packages to require-dev instead of require. These are: dev, testing, static analysis.