### PR TITLE
PHPUnit test provider method should be static

### DIFF
--- a/src/Test/LoggerInterfaceTest.php
+++ b/src/Test/LoggerInterfaceTest.php
@@ -54,7 +54,7 @@ abstract class LoggerInterfaceTest extends TestCase
         $this->assertEquals($expected, $this->getLogs());
     }
 
-    public function provideLevelsAndMessages()
+    public static function provideLevelsAndMessages()
     {
         return [
             LogLevel::EMERGENCY => [LogLevel::EMERGENCY, 'message of level emergency with context: {user}'],


### PR DESCRIPTION
Currently, composer.json does not specify which PHPUnit version it are using, 
but it should be a static method at least for PHPUnit 8 and later.