### PR TITLE
Updated - hasRecord() PHPDoc type hint, reflecting the actual method implementation

### DIFF
--- a/src/Test/TestLogger.php
+++ b/src/Test/TestLogger.php
@@ -42,7 +42,7 @@ class TestLogger implements LoggerInterface
     }
 
     /**
-     * @param array $record
+     * @param array|string $record
      * @param string $level
      * @return bool
      */


### PR DESCRIPTION
I found this with PHPStan level 5
```
vendor/bin/phpstan analyse --level=5 src
 3/3 [▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓] 100%

 ------ --------------------------------------------------------------------------------------------------------------------------------------------
  Line   Test/TestLogger.php
 ------ --------------------------------------------------------------------------------------------------------------------------------------------
  51     Call to function is_string() with array will always evaluate to false.
         🪪  function.impossibleType
         💡 Because the type is coming from a PHPDoc, you can turn off this check by setting treatPhpDocTypesAsCertain: false in your phpstan.neon.
 ------ --------------------------------------------------------------------------------------------------------------------------------------------



 [ERROR] Found 1 error

```