### PR TITLE
feature: Add optional PSR-3 message placeholder interpolation to TestLogger

### DIFF
--- a/tests/Test/TestLoggerTest.php
+++ b/tests/Test/TestLoggerTest.php
@@ -116,4 +116,12 @@ class TestLoggerTest extends LoggerInterfaceTest
         $this->assertFalse($logger->hasDebugThatMatches('/warning message/'));
         $this->assertFalse($logger->hasDebugThatPasses(fn (array $record) => 'warning message' === $record['message']));
     }
+
+    public function testPlaceholderInterpolation() : void
+    {
+        $logger = new TestLogger(true);
+        $message = 'User {username} created';
+        $logger->debug($message, ['username' => 'bolivar']);
+        $this->assertTrue($logger->hasDebugThatContains('User bolivar created'));
+    }
 }


### PR DESCRIPTION
Introduces an optional placeholder interpolation feature that allows TestLogger to interpolate context values into message placeholders.
 (e.g., "User {username} created" with context ['username' => 'bolivar']).
This makes it easier to test log messages with dynamic values.

I often want asserting placeholder interpolation message.

```php
$this->assertTrue($logger->hasDebugThatContains('User bolivar created'));
```