### PR TITLE
[WIP] assert context offset exception is Throwable

### DIFF
--- a/src/Test/TestLogger.php
+++ b/src/Test/TestLogger.php
@@ -33,6 +33,8 @@ class TestLogger implements LoggerInterface
      */
     public function log($level, string|\Stringable $message, array $context = []): void
     {
+        assert(isset($context['exception']) ? $context['exception'] instanceof \Throwable : true);
+
         if ($this->placeholderInterpolation === true) {
             $message = $this->interpolate($message, $context);
         }


### PR DESCRIPTION
At #15, introduced array shape `context: array{exception?: \Throwable}`.
But I missed asserting for this.

Regarding #17, I'm wondering if I should change it to `context: array<array-key, mixed>`