### PR TITLE
Widen context type to mixed[]

### DIFF
--- a/src/Test/TestLogger.php
+++ b/src/Test/TestLogger.php
@@ -10,7 +10,7 @@ use Psr\Log\LoggerTrait;
  *
  * It records all records and gives you access to them for verification.
  *
- * @psalm-type log_record_array array{level: string, message: string|\Stringable, context: array{exception?: \Throwable}}
+ * @psalm-type log_record_array array{level: string, message: string|\Stringable, context: mixed[]}
  */
 class TestLogger implements LoggerInterface
 {


### PR DESCRIPTION
Fixes #17.

We currently document the context as `array{exception?: \Throwable}` which static analyzers interpret as, this array can only contain the key `exception` and if it does, an instance of `Throwable` is stored there. This is too narrow because according to the specification, the context may have any shape.

This PR widens the type of the log context to `mixed[]` which is also how the specification documents it:

https://github.com/php-fig/log/blob/f16e1d5863e37f8d8c2a01719f5b34baa2b714d3/src/LoggerInterface.php#L93

The context may have any shape and while the specification explicitly mentiones the `exception` key, it also states that the key may still contain anything.

https://www.php-fig.org/psr/psr-3/#13-context