### PR TITLE
Fix CI run

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -1,11 +1,10 @@
 name: Testing
 on:
-  pull_request: ~
+  pull_request:
   push:
-    branches:
-      - main
   schedule:
-    - cron: "30 6 * * 1"
+    - cron: "30 6 1 * *"
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -1,9 +1,7 @@
 name: Testing
 on:
-  pull_request:
+  pull_request: 
   push:
-  schedule:
-    - cron: "30 6 1 * *"
 
 jobs:
   build:
@@ -16,6 +14,7 @@ jobs:
           - 8.2
           - 8.3
           - 8.4
+          - 8.5
         dependency-levels:
           - 'highest'
         experimental:


### PR DESCRIPTION
- Added php 8.5
- Removed cron schedule because after 60days without activity on the repo GitHub then disables that entire workflow.. so this is kinda counter productive in a repo like this which doesn't see much activity.